### PR TITLE
docs: reference architecture overview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,71 @@
+# Architekturüberblick
+
+Diese Datei fasst die geplante Architektur eines selbstgehosteten Knowledge Hubs zusammen. AppFlowy und AFFiNE dienen als bidirektional vernetzte Knowledge Hubs. n8n orchestriert den Datenaustausch zwischen allen Komponenten und ein lokaler LLM-Agent stellt per RAG Funktionalität bereit.
+
+## Kernkomponenten
+
+- **Supabase (PostgreSQL)** – zentrale Datenbank mit `pgvector` und S3 Storage.
+- **Qdrant** und **Weaviate** – Vektor-Datenbanken zur semantischen Suche.
+- **AppFlowy** und **AFFiNE** – Wissensfrontends mit PostgreSQL-Backend.
+- **n8n** – Integrations- und Automatisierungsplattform.
+- **Ollama LLM-Agent** – lokaler LLM für Retrieval-Augmented Generation.
+
+## Datenflüsse
+
+1. Neue Inhalte in AppFlowy oder AFFiNE lösen Workflows in n8n aus.
+2. n8n erzeugt Embeddings mittels Ollama und speichert sie in Qdrant bzw. Weaviate.
+3. Änderungen werden in Supabase gespiegelt und optional in andere Systeme synchronisiert.
+4. Der LLM-Agent nutzt die Vektor-Datenbanken für semantische Anfragen aus allen Frontends.
+
+## Sicherheit und Monitoring
+
+- Zentrale Authentifizierung über Supabase oder die nativen Systeme.
+- Caddy reverse proxy bietet HTTPS für alle Dienste.
+- Prometheus und Grafana überwachen die Umgebung.
+
+## Visualisierung
+
+```mermaid
+flowchart TD
+  subgraph Frontends
+    AF(AppFlowy)
+    AFF(AFFiNE)
+    OW(Open WebUI)
+    N8(n8n-UI)
+    CLI(CLI/Flowise/Letta)
+  end
+
+  subgraph Datenbanken
+    SB(Supabase/Postgres)
+    QD(Qdrant)
+    WV(Weaviate)
+    S3(S3/Buckets)
+  end
+
+  subgraph KI-Layer
+    LLM(Ollama LLM-Agent)
+    FLW(Flowise/Letta)
+  end
+
+  AF <--> SB
+  AFF <--> SB
+  AF <--> N8
+  AFF <--> N8
+  N8 <--> QD
+  N8 <--> WV
+  N8 <--> SB
+  N8 <--> LLM
+  N8 <--> FLW
+  LLM <--> QD
+  LLM <--> WV
+  LLM <--> SB
+  OW <--> LLM
+  AF <--> LLM
+  AFF <--> LLM
+  CLI <--> LLM
+  FLW <--> LLM
+  S3 <--> AFF
+  S3 <--> SB
+```
+
+Diese Architektur ermöglicht eine erweiterbare Self‑Hosted‑Platform, die Daten aus allen Quellen zusammenführt und über den LLM-Agenten kontextbezogen bereitstellt.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **n8n Installer** is an open-source Docker Compose template designed to significantly simplify setting up a comprehensive, self-hosted environment for n8n and Flowise. It bundles essential supporting tools like Open WebUI (as an interface for n8n agents), Supabase (database, vector information storage, authentication), Qdrant (high-performance vector information storage), Langfuse (to observe AI model performance), SearXNG (private metasearch), Grafana/Prometheus (monitoring), Crawl4ai (web crawling), AppFlowy (knowledge management), Affine (collaborative workspace), and Caddy (for managed HTTPS). Plus, during setup, you can optionally import over 300 community workflows into your n8n instance!
 
+For an overview of the full Knowledge Hub architecture, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
 ### Why This Setup?
 
 This installer helps you create your own powerful, private AI workshop. Imagine having a suite of tools at your fingertips to:


### PR DESCRIPTION
Added a new architecture overview describing how AppFlowy and AFFiNE integrate with n8n, Qdrant, Weaviate, Supabase, and the local LLM agent

Updated the README to reference the new architecture documentation for an at-a-glance view of the full Knowledge Hub design
