### PR TITLE
Add Debian packaging for n8n installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ shared-backup/
 shared/
 supabase/
 volumes/
+# Packaging
+packaging/deb/pkgroot/
+packaging/deb/*.deb

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,18 @@
+# Building the n8n-installer Debian package
+
+This directory contains files to create a simple `.deb` package for the
+n8n-installer project. The resulting package copies the repository to
+`/opt/n8n-installer` and runs the included installation scripts to set up
+required dependencies.
+
+## Build the package
+
+Run the `build.sh` script inside `packaging/deb`:
+
+```bash
+cd packaging/deb
+./build.sh
+```
+
+After the script finishes, you will have `n8n-installer.deb` in the same
+folder which can be installed with `dpkg -i`.

--- a/packaging/deb/DEBIAN/control
+++ b/packaging/deb/DEBIAN/control
@@ -1,0 +1,9 @@
+Package: n8n-installer
+Version: 1.0
+Section: admin
+Priority: optional
+Architecture: all
+Maintainer: n8n community <info@n8n.io>
+Description: n8n-installer setup package with workspace utilities
+ This package installs the n8n-installer workspace and runs
+ installation scripts to set up all required dependencies.

--- a/packaging/deb/DEBIAN/postinst
+++ b/packaging/deb/DEBIAN/postinst
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+cd /opt/n8n-installer/scripts
+bash install.sh

--- a/packaging/deb/build.sh
+++ b/packaging/deb/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PKGROOT="$SCRIPT_DIR/pkgroot"
+
+# Clean previous build
+rm -rf "$PKGROOT"
+mkdir -p "$PKGROOT/DEBIAN"
+mkdir -p "$PKGROOT/opt/n8n-installer"
+mkdir -p "$PKGROOT/usr/local/bin"
+
+# Copy DEBIAN control files
+cp "$SCRIPT_DIR/DEBIAN/control" "$PKGROOT/DEBIAN/control"
+cp "$SCRIPT_DIR/DEBIAN/postinst" "$PKGROOT/DEBIAN/postinst"
+chmod 755 "$PKGROOT/DEBIAN/postinst"
+
+# Copy project excluding git and packaging folder
+rsync -a --exclude '.git' --exclude 'packaging' "$ROOT_DIR/" "$PKGROOT/opt/n8n-installer/"
+
+# Wrapper executable
+cat <<'EOS' > "$PKGROOT/usr/local/bin/n8n-installer"
+#!/bin/bash
+cd /opt/n8n-installer
+sudo bash ./scripts/install.sh
+EOS
+chmod +x "$PKGROOT/usr/local/bin/n8n-installer"
+
+# Build package
+cd "$SCRIPT_DIR"
+dpkg-deb --build pkgroot n8n-installer.deb


### PR DESCRIPTION
## Summary
- provide Debian packaging scripts
- ignore built packages

## Testing
- `dpkg-deb --build pkgroot n8n-installer.deb` *(via `build.sh`)*

------
https://chatgpt.com/codex/tasks/task_e_685d268a29248324866d1a7e1c34dda2