### PR TITLE
Add test suite scaffolding

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,17 @@
+# TODO for Test Suite
+
+This repository lacks automated tests. To provide a comprehensive suite the following tasks are planned:
+
+- [ ] Add pytest configuration and create `tests/` directory.
+- [ ] Cover functions in `n8n_pipe.py`:
+  - `extract_event_info`
+  - `Pipe._extract_knowledge_keywords`
+  - `Pipe.check_knowledge_sources`
+- [ ] Cover utilities in `start_services.py`:
+  - System check helpers (`_check_memory`, `_check_disk_space`, `_get_os_info`, `_check_docker`, `_check_docker_compose`)
+  - `check_system_requirements`
+  - `get_enabled_services`
+  - `check_editor_configuration`
+  - generation helpers (`_get_status_script`, `_get_logs_script`, `_get_backup_script`, `_get_dev_session_script`)
+- [ ] Ensure tests run without external dependencies by mocking subprocess and file system calls.
+- [ ] Run all tests via `pytest`.

--- a/tests/test_n8n_pipe.py
+++ b/tests/test_n8n_pipe.py
@@ -1,0 +1,49 @@
+import pytest
+
+from n8n_pipe import extract_event_info, Pipe
+
+
+def make_emitter():
+    request_info = {"chat_id": "123", "message_id": "456"}
+
+    async def emitter(event):
+        _ = request_info  # capture in closure for extract_event_info
+        return None
+
+    return emitter
+
+
+def test_extract_event_info():
+    emitter = make_emitter()
+    chat_id, message_id = extract_event_info(emitter)
+    assert chat_id == "123"
+    assert message_id == "456"
+
+
+def test_extract_knowledge_keywords():
+    pipe = Pipe()
+    text = "This document discusses project plans and team meeting notes"
+    keywords = pipe._extract_knowledge_keywords(text)
+    assert "document" in keywords
+    assert "project" in keywords
+    assert "meeting" in keywords
+
+
+@pytest.mark.asyncio
+async def test_check_knowledge_sources_enabled():
+    pipe = Pipe()
+    pipe.valves.enable_knowledge_integration = True
+    pipe.valves.appflowy_url = "https://appflowy.example.com"
+    pipe.valves.affine_url = "https://affine.example.com"
+    result = await pipe.check_knowledge_sources("project plan")
+    assert result["appflowy_available"] is True
+    assert result["affine_available"] is True
+    assert result["sources"]
+
+
+@pytest.mark.asyncio
+async def test_check_knowledge_sources_disabled():
+    pipe = Pipe()
+    pipe.valves.enable_knowledge_integration = False
+    result = await pipe.check_knowledge_sources("anything")
+    assert result == {"knowledge_context": None, "sources": []}

--- a/tests/test_start_services.py
+++ b/tests/test_start_services.py
@@ -1,0 +1,56 @@
+from unittest import mock
+
+import pytest
+
+from start_services import EnhancedWorkspaceManager
+
+
+@pytest.fixture
+def workspace():
+    return EnhancedWorkspaceManager()
+
+
+def test_get_enabled_services(monkeypatch, workspace):
+    with mock.patch('start_services.dotenv_values', return_value={'COMPOSE_PROFILES': 'n8n,flowise,affine'}):
+        services = workspace.get_enabled_services()
+    assert services['n8n']
+    assert services['flowise']
+    assert services['affine']
+    assert not services['portainer']
+
+
+def test_check_editor_configuration(tmp_path, monkeypatch, workspace):
+    config_dir = tmp_path / 'editor-config'
+    config_dir.mkdir()
+    cfg_path = config_dir / 'editor-choice.json'
+    cfg_path.write_text('{"configured": true, "editor_type": "vscode", "installation_type": "native"}')
+    monkeypatch.setattr(workspace, 'config_dir', config_dir)
+    result = workspace.check_editor_configuration()
+    assert result['configured']
+    assert result['editor_type'] == 'vscode'
+
+
+def test_get_status_script(workspace):
+    script = workspace._get_status_script()
+    assert 'docker ps' in script
+
+
+def test_get_logs_script(workspace):
+    script = workspace._get_logs_script()
+    assert 'docker logs' in script
+
+
+def test_check_system_requirements(monkeypatch, workspace):
+    monkeypatch.setattr(workspace, '_check_docker', lambda: {'available': True, 'version': 'docker', 'daemon_running': True})
+    monkeypatch.setattr(workspace, '_check_docker_compose', lambda: {'available': True, 'command': 'docker compose', 'version': 'v2'})
+    monkeypatch.setattr(workspace, '_check_memory', lambda: {'total_gb': 8, 'available_gb': 8})
+    monkeypatch.setattr(workspace, '_check_disk_space', lambda: {'free_gb': 100, 'total_gb': 200})
+    monkeypatch.setattr(workspace, '_get_architecture', lambda: 'x86_64')
+    monkeypatch.setattr(workspace, '_get_os_info', lambda: {'name': 'Ubuntu', 'version': '22.04'})
+    monkeypatch.setattr(workspace, '_check_network', lambda: {'connected': True})
+    monkeypatch.setattr(workspace, '_check_permissions', lambda: {'sufficient': True, 'docker_accessible': True, 'can_install': True})
+
+    result = workspace.check_system_requirements()
+    assert result['docker']['available']
+    assert result['compose']['available']
+    assert result['memory']['available_gb'] == 8


### PR DESCRIPTION
## Summary
- add TODO for developing test suite
- add basic pytest-based tests for `n8n_pipe` and `start_services`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685d5c6a63f48324bd12359063a647f0