### PR TITLE
Add AI Workspace Portal

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -506,3 +506,12 @@ rate_limit {
 }
 
 respond @blocked_patterns "Forbidden" 403
+
+# =============================================================================
+# AI WORKSPACE PORTAL
+# =============================================================================
+
+{$USER_DOMAIN_NAME:localhost} {
+    root * /usr/share/caddy
+    file_server
+}

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ After successful installation, your services are up and running! Here's how to g
 1.  **Access Your Services:**
     The installation script provided a summary report with all access URLs and credentials. Please refer to that report. The main services will be available at the following addresses (replace `yourdomain.com` with your actual domain):
 
+    - **Workspace Portal:** `https://yourdomain.com` (Landing page linking to all services)
     - **n8n:** `n8n.yourdomain.com` (Log in with the email address you provided during installation and the initial password from the summary report. You may be prompted to change this password on first login.)
     - **Open WebUI:** `webui.yourdomain.com`
     - **Flowise:** `flowise.yourdomain.com` (Log in with the email address you provided during installation and the initial password from the summary report.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -304,6 +304,7 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data:rw
       - caddy_config:/config:rw
+      - ./AI-Workspace-Portal.html:/usr/share/caddy/index.html:ro
     networks:
       - internal_network
     healthcheck:

--- a/scripts/06_final_report.sh
+++ b/scripts/06_final_report.sh
@@ -1010,6 +1010,8 @@ show_quick_access_guide() {
     echo "───────────────────────────"
     local domain="${USER_DOMAIN_NAME:-localhost}"
     local protocol=$([ "$domain" != "localhost" ] && echo "https" || echo "http")
+    local portal_url="$protocol://$domain"
+    echo "   🚀 Workspace Portal: $portal_url"
     
     if is_profile_active "n8n"; then
         local n8n_url="$protocol://${N8N_HOSTNAME:-localhost:5678}"


### PR DESCRIPTION
## Summary
- expose AI Workspace Portal through Caddy and docker-compose
- mention the portal in README quick start
- show portal URL in final report

## Testing
- `python -m pytest tests/` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `bash ./scripts/update.sh` *(fails: Failed to update .env configuration via 03_generate_secrets.sh)*

------
https://chatgpt.com/codex/tasks/task_e_685d68e3ec988324a096a1d5cb57d115