### PR TITLE
Integrate Agent-NN service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -332,6 +332,13 @@ LETTA_HOSTNAME=letta.yourdomain.com
 LETTA_SERVER_PASSWORD=
 LETTA_SECURE=true
 
+############
+# [OPTIONAL] Agent-NN Multi-Agent System
+# Modular agent framework
+############
+
+AGENTNN_HOSTNAME=agentnn.yourdomain.com
+
 ################################################################################
 # DEVELOPMENT ENVIRONMENT
 ################################################################################
@@ -489,6 +496,7 @@ BETA_ADVANCED_ANALYTICS=false
 # PROMETHEUS_HOSTNAME=prometheus.yourdomain.com
 # LETTA_HOSTNAME=letta.yourdomain.com
 # QDRANT_HOSTNAME=qdrant.yourdomain.com
+# AGENTNN_HOSTNAME=agentnn.yourdomain.com
 
 ################################################################################
 # LEGACY COMPATIBILITY

--- a/Caddyfile
+++ b/Caddyfile
@@ -378,6 +378,22 @@ letta.{$USER_DOMAIN_NAME:localhost} {
     
     encode gzip
 }
+# Agent-NN API
+agentnn.{$USER_DOMAIN_NAME:localhost} {
+    reverse_proxy agentnn-dispatcher:8000 {
+        header_up Host {host}
+        header_up X-Real-IP {remote}
+        header_up X-Forwarded-For {remote}
+        header_up X-Forwarded-Proto {scheme}
+    }
+
+    log {
+        output file /var/log/caddy/agentnn.log
+    }
+
+    encode gzip
+}
+
 
 # =============================================================================
 # DEVELOPMENT ENVIRONMENT (Optional code-server)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The installer also makes the following powerful open-source tools **available fo
 ✅ [**Crawl4ai**](https://github.com/Alfresco/crawl4ai) - A flexible web crawler designed for AI, enabling you to extract data from websites for your projects.
 
 ✅ [**Letta**](https://docs.letta.com/) - An open-source agent server and SDK that can be connected to various LLM API backends (OpenAI, Anthropic, Ollama, etc.), enabling you to build and manage AI agents.
+✅ [**Agent-NN**](https://github.com/EcoSphereNetwork/Agent-NN) - Modular multi-agent system with dispatcher and worker services.
 
 ✅ [**Weaviate**](https://weaviate.io/) - An open-source AI-native vector database with a focus on scalability and ease of use. It can be used for RAG, hybrid search, and more.
 
@@ -133,6 +134,7 @@ After successful installation, your services are up and running! Here's how to g
     - **Supabase (Dashboard):** `supabase.yourdomain.com`
     - **Langfuse:** `langfuse.yourdomain.com`
     - **Letta:** `letta.yourdomain.com`
+    - **Agent-NN:** `agentnn.yourdomain.com`
     - **Weaviate:** `weaviate.yourdomain.com`
     - **Neo4j:** `neo4j.yourdomain.com`
     - **Grafana:** `grafana.yourdomain.com`

--- a/ai-docs/agent-nn-integration.md
+++ b/ai-docs/agent-nn-integration.md
@@ -1,0 +1,11 @@
+# Agent-NN Integration
+
+The installer now includes the [Agent-NN](https://github.com/EcoSphereNetwork/Agent-NN) framework. It provides a dispatcher, registry, session manager, vector store and several worker services.
+
+## Usage
+
+1. Set `AGENTNN_HOSTNAME` in your `.env` file and add `agent-nn` to `COMPOSE_PROFILES`.
+2. Start the services with `docker compose up -d` or run the installation script.
+3. Access the API at `agentnn.yourdomain.com` via Caddy.
+
+To use the n8n node provided by Agent-NN, navigate to `integrations/n8n-agentnn` in the Agent-NN repository, run `npm install && npx tsc`, and copy the files from `dist/` to your `~/.n8n/custom` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1293,7 +1293,109 @@ services:
       resources:
         limits:
           memory: 2G
-          cpus: '1.0'
+      cpus: '1.0'
+
+  # Agent-NN Multi-Agent Framework
+  agentnn-redis:
+    image: redis:7
+    container_name: agentnn-redis
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    networks:
+      - internal_network
+    healthcheck:
+      <<: *healthcheck-defaults
+      test: ["CMD", "redis-cli", "ping"]
+
+  agentnn-session-manager:
+    image: ghcr.io/ecospherNetwork/agent-nn/session_manager:latest
+    container_name: agentnn-session-manager
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    environment:
+      <<: *common-env
+      REDIS_HOST: agentnn-redis
+    depends_on:
+      - agentnn-redis
+    networks:
+      - internal_network
+
+  agentnn-registry:
+    image: ghcr.io/ecospherNetwork/agent-nn/registry:latest
+    container_name: agentnn-registry
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    networks:
+      - internal_network
+
+  agentnn-vector-store:
+    image: ghcr.io/ecospherNetwork/agent-nn/vector_store:latest
+    container_name: agentnn-vector-store
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    volumes:
+      - agentnn_vector_data:/data
+    networks:
+      - internal_network
+
+  agentnn-llm-gateway:
+    image: ghcr.io/ecospherNetwork/agent-nn/llm_gateway:latest
+    container_name: agentnn-llm-gateway
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    environment:
+      <<: *common-env
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama:11434}
+    networks:
+      - internal_network
+
+  agentnn-dispatcher:
+    image: ghcr.io/ecospherNetwork/agent-nn/dispatcher:latest
+    container_name: agentnn-dispatcher
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    depends_on:
+      - agentnn-registry
+      - agentnn-session-manager
+      - agentnn-vector-store
+      - agentnn-llm-gateway
+    networks:
+      - internal_network
+
+  agentnn-worker-dev:
+    image: ghcr.io/ecospherNetwork/agent-nn/worker_dev:latest
+    container_name: agentnn-worker-dev
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    networks:
+      - internal_network
+
+  agentnn-worker-loh:
+    image: ghcr.io/ecospherNetwork/agent-nn/worker_loh:latest
+    container_name: agentnn-worker-loh
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    networks:
+      - internal_network
+
+  agentnn-worker-openhands:
+    image: ghcr.io/ecospherNetwork/agent-nn/worker_openhands:latest
+    container_name: agentnn-worker-openhands
+    profiles: ["agent-nn"]
+    <<: *restart-policy
+    <<: *default-logging
+    networks:
+      - internal_network
 
   # =============================================================================
   # MODEL PULLING SERVICES (One-time execution)

--- a/start_services.py
+++ b/start_services.py
@@ -88,6 +88,15 @@ class EnhancedWorkspaceManager:
             'searxng': [],
             'crawl4ai': [],
             'letta': [],
+            'agentnn-dispatcher': ['agentnn-registry', 'agentnn-session-manager', 'agentnn-vector-store', 'agentnn-llm-gateway'],
+            'agentnn-registry': [],
+            'agentnn-session-manager': ['agentnn-redis'],
+            'agentnn-vector-store': [],
+            'agentnn-llm-gateway': [],
+            'agentnn-worker-dev': [],
+            'agentnn-worker-loh': [],
+            'agentnn-worker-openhands': [],
+            'agentnn-redis': [],
             
             # Ollama variants
             'ollama-cpu': [],
@@ -338,6 +347,7 @@ class EnhancedWorkspaceManager:
             'searxng': 'searxng' in compose_profiles,
             'crawl4ai': 'crawl4ai' in compose_profiles,
             'letta': 'letta' in compose_profiles,
+            'agentnn': 'agent-nn' in compose_profiles,
             
             # Ollama variants
             'ollama': any(profile in compose_profiles for profile in ['cpu', 'gpu-nvidia', 'gpu-amd']),


### PR DESCRIPTION
## Summary
- add Agent-NN bullet points to README and list hostname
- document Agent-NN environment variables
- include Agent-NN services in docker-compose
- wire Agent-NN into service manager
- expose Agent-NN via Caddy
- add short integration doc

## Testing
- `pytest -q`
- `bash ./scripts/update.sh` *(fails: "E: Unable to locate package caddy")*

------
https://chatgpt.com/codex/tasks/task_e_6865675d61048324bd85e6269193d7ac