### PR TITLE
Add Zed editor integration docs and fix wizard paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ After successful installation, your services are up and running! Here's how to g
 5.  **Check Monitoring (Optional):**
     - Visit Grafana (`grafana.yourdomain.com`) to see dashboards monitoring your system's performance (data sourced from Prometheus).
 
+6.  **Set Up the Zed Editor (Optional):**
+    - Run `python scripts/editor_selection.py` to generate an installation script.
+    - Execute the script in `editor-config/` to install Zed.
+    - See [docs/zed_editor_setup.md](docs/zed_editor_setup.md) for details.
+
 ### Proxmox Deployment with LXD
 
 Use the helper scripts when deploying on Proxmox:

--- a/docs/zed_editor_setup.md
+++ b/docs/zed_editor_setup.md
@@ -1,0 +1,29 @@
+# Zed Editor Integration
+
+The installer allows you to configure Zed as your primary development editor.
+This lightweight editor offers collaborative features and AI assistance.
+
+## Selecting the Editor
+
+During the interactive service wizard a prompt appears asking if you want to
+configure a development editor. Choose **Zed Editor (Native)** when prompted.
+You can also run the selection later:
+
+```bash
+python scripts/editor_selection.py
+```
+
+This command generates an installation script under `editor-config/`. Execute
+it with sudo privileges to install Zed system wide.
+
+## Launching Zed
+
+Once installed, launch the editor from your terminal:
+
+```bash
+zed ~/Projects/
+```
+
+Your projects directory is prepared by the installer inside `~/Projects/`.
+
+For additional options visit the [official Zed documentation](https://zed.dev/docs/).

--- a/scripts/04_wizard.sh
+++ b/scripts/04_wizard.sh
@@ -235,7 +235,7 @@ You can choose between multiple editor options:
    • Web-based access options
 
 Would you like to configure your development editor now?
-(You can also run this later with: python _editor_selection.py)" 18 85
+(You can also run this later with: python scripts/editor_selection.py)" 18 85
         
         if [ $? -eq 0 ]; then
             run_editor_selection
@@ -245,8 +245,8 @@ Would you like to configure your development editor now?
 
 # Function to run editor selection
 run_editor_selection() {
-    # Check if the  editor selection script exists
-    local editor_script="$PROJECT_ROOT/_editor_selection.py"
+    # Check if the editor selection script exists
+    local editor_script="$PROJECT_ROOT/scripts/editor_selection.py"
     
     if [ ! -f "$editor_script" ]; then
         whiptail --title "Editor Selection" --msgbox \

--- a/scripts/06_final_report.sh
+++ b/scripts/06_final_report.sh
@@ -485,7 +485,7 @@ show_development_environment() {
         echo "   🐳 Container Options - Isolated development environments"
         echo ""
         echo "💡 Setup Instructions:"
-        echo "   🔧 Run: python editor_selection.py"
+        echo "   🔧 Run: python scripts/editor_selection.py"
         echo "   📋 Follow interactive configuration wizard"
     fi
     
@@ -1046,7 +1046,7 @@ show_quick_access_guide() {
         echo "   📁 Open projects: $editor_type ~/Projects/"
         echo "   🔧 Editor config: ~/.config/$editor_type/"
     else
-        echo "   🎨 Setup editor: python editor_selection.py"
+        echo "   🎨 Setup editor: python scripts/editor_selection.py"
     fi
     
     echo "   📂 Project directory: cd ~/Projects/"


### PR DESCRIPTION
## Summary
- integrate Zed editor references in wizard and final report
- document Zed editor setup in new file
- mention editor setup in README

## Testing
- `bash -n scripts/04_wizard.sh`
- `bash -n scripts/06_final_report.sh`
- `python -m pytest tests/` *(fails: ModuleNotFoundError: pydantic)*
- `bash ./scripts/update.sh` *(fails: apt unable to locate caddy)*

------
https://chatgpt.com/codex/tasks/task_e_686573d8e9d08324af692b10a6e79eeb